### PR TITLE
Fix hard coded kit name path and make building a lot easier v2

### DIFF
--- a/QtSnap-DemoApp/QtSnap-DemoApp.pro
+++ b/QtSnap-DemoApp/QtSnap-DemoApp.pro
@@ -16,14 +16,14 @@ CONFIG   -= app_bundle
 CONFIG += c++11
 CONFIG += c++14
 
-
 TEMPLATE = app
-
 
 SOURCES += main.cpp
 
-win32: LIBS += -L$$PWD/../build-QtSnap-Library-Desktop_Qt_5_4_0_MinGW_32bit-Debug/debug/ -lQtSnap-Library
-macx: LIBS += -L$$PWD/../build-QtSnap-Library-Desktop_Qt_5_4_0_clang_64bit-Debug/ -lQtSnap-Library
-
 INCLUDEPATH += $$PWD/../QtSnap-Library
 DEPENDPATH += $$PWD/../QtSnap-Library
+
+unix|win32: LIBS += -L$$OUT_PWD/../QtSnap-Library/ -lQtSnap-Library
+
+win32:!win32-g++: PRE_TARGETDEPS += $$OUT_PWD/../QtSnap-Library/QtSnap-Library.lib
+else:unix|win32-g++: PRE_TARGETDEPS += $$OUT_PWD/../QtSnap-Library/libQtSnap-Library.a

--- a/QtSnap.pro
+++ b/QtSnap.pro
@@ -1,0 +1,5 @@
+TEMPLATE=subdirs
+SUBDIRS = lib app
+lib.subdir = QtSnap-Library
+app.subdir = QtSnap-DemoApp
+app.depend = lib


### PR DESCRIPTION
Use qmake subdirs project to properly handle dependencies and avoid hard coding kit name paths for dependencies.
